### PR TITLE
2018 edition macro imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license="MIT"
 description = "Macros for easy operator overloading."
 keywords = ["macro", "operator", "overloading", "impl", "op"]
 categories = ["rust-patterns"]
+edition = "2018"
 repository = "https://github.com/brianwp3000/impl_ops"
 include = [
     "**/*.rs",

--- a/src/assignment.rs
+++ b/src/assignment.rs
@@ -16,20 +16,20 @@ macro_rules! _parse_assignment_op {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _impl_assignment_op_internal {
-    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, &$rhs:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => (        
+    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, &$rhs:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => {
         impl<'a> ops::$ops_trait<&'a $rhs> for $lhs {
             fn $ops_fn(&mut self, $rhs_i: &$rhs) {
                 let mut $lhs_i = self;
                 $body
             }
         }
-    );
-    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => (        
+    };
+    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => {
         impl ops::$ops_trait<$rhs> for $lhs {
             fn $ops_fn(&mut self, $rhs_i: $rhs) {
                 let mut $lhs_i = self;
                 $body
             }
         }
-    );
+    };
 }

--- a/src/assignment.rs
+++ b/src/assignment.rs
@@ -1,16 +1,16 @@
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _parse_assignment_op {
-    (+=, $($t:tt)+) => (_impl_assignment_op_internal!(AddAssign, add_assign, $($t)+););
-    (-=, $($t:tt)+) => (_impl_assignment_op_internal!(SubAssign, sub_assign, $($t)+););
-    (*=, $($t:tt)+) => (_impl_assignment_op_internal!(MulAssign, mul_assign, $($t)+););
-    (/=, $($t:tt)+) => (_impl_assignment_op_internal!(DivAssign, div_assign, $($t)+););
-    (%=, $($t:tt)+) => (_impl_assignment_op_internal!(RemAssign, rem_assign, $($t)+););
-    (&=, $($t:tt)+) => (_impl_assignment_op_internal!(BitAndAssign, bitand_assign, $($t)+););
-    (|=, $($t:tt)+) => (_impl_assignment_op_internal!(BitOrAssign, bitor_assign, $($t)+););
-    (^=, $($t:tt)+) => (_impl_assignment_op_internal!(BitXorAssign, bitxor_assign, $($t)+););
-    (<<=, $($t:tt)+) => (_impl_assignment_op_internal!(ShlAssign, shl_assign, $($t)+););
-    (>>=, $($t:tt)+) => (_impl_assignment_op_internal!(ShrAssign, shr_assign, $($t)+););
+    (+=, $($t:tt)+) => ($crate::_impl_assignment_op_internal!(AddAssign, add_assign, $($t)+););
+    (-=, $($t:tt)+) => ($crate::_impl_assignment_op_internal!(SubAssign, sub_assign, $($t)+););
+    (*=, $($t:tt)+) => ($crate::_impl_assignment_op_internal!(MulAssign, mul_assign, $($t)+););
+    (/=, $($t:tt)+) => ($crate::_impl_assignment_op_internal!(DivAssign, div_assign, $($t)+););
+    (%=, $($t:tt)+) => ($crate::_impl_assignment_op_internal!(RemAssign, rem_assign, $($t)+););
+    (&=, $($t:tt)+) => ($crate::_impl_assignment_op_internal!(BitAndAssign, bitand_assign, $($t)+););
+    (|=, $($t:tt)+) => ($crate::_impl_assignment_op_internal!(BitOrAssign, bitor_assign, $($t)+););
+    (^=, $($t:tt)+) => ($crate::_impl_assignment_op_internal!(BitXorAssign, bitxor_assign, $($t)+););
+    (<<=, $($t:tt)+) => ($crate::_impl_assignment_op_internal!(ShlAssign, shl_assign, $($t)+););
+    (>>=, $($t:tt)+) => ($crate::_impl_assignment_op_internal!(ShrAssign, shr_assign, $($t)+););
 }
 
 #[doc(hidden)]

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -1,38 +1,40 @@
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _parse_binary_op {
-    (+, $($t:tt)+) => (_impl_binary_op_internal!(Add, add, $($t)+););
-    (-, $($t:tt)+) => (_impl_binary_op_internal!(Sub, sub, $($t)+););
-    (*, $($t:tt)+) => (_impl_binary_op_internal!(Mul, mul, $($t)+););
-    (/, $($t:tt)+) => (_impl_binary_op_internal!(Div, div, $($t)+););
-    (%, $($t:tt)+) => (_impl_binary_op_internal!(Rem, rem, $($t)+););
-    (&, $($t:tt)+) => (_impl_binary_op_internal!(BitAnd, bitand, $($t)+););
-    (|, $($t:tt)+) => (_impl_binary_op_internal!(BitOr, bitor, $($t)+););
-    (^, $($t:tt)+) => (_impl_binary_op_internal!(BitXor, bitxor, $($t)+););
-    (<<, $($t:tt)+) => (_impl_binary_op_internal!(Shl, shl, $($t)+););
-    (>>, $($t:tt)+) => (_impl_binary_op_internal!(Shr, shr, $($t)+););
+    (+, $($t:tt)+) => ($crate::_impl_binary_op_internal!(Add, add, $($t)+););
+    (-, $($t:tt)+) => ($crate::_impl_binary_op_internal!(Sub, sub, $($t)+););
+    (*, $($t:tt)+) => ($crate::_impl_binary_op_internal!(Mul, mul, $($t)+););
+    (/, $($t:tt)+) => ($crate::_impl_binary_op_internal!(Div, div, $($t)+););
+    (%, $($t:tt)+) => ($crate::_impl_binary_op_internal!(Rem, rem, $($t)+););
+    (&, $($t:tt)+) => ($crate::_impl_binary_op_internal!(BitAnd, bitand, $($t)+););
+    (|, $($t:tt)+) => ($crate::_impl_binary_op_internal!(BitOr, bitor, $($t)+););
+    (^, $($t:tt)+) => ($crate::_impl_binary_op_internal!(BitXor, bitxor, $($t)+););
+    (<<, $($t:tt)+) => ($crate::_impl_binary_op_internal!(Shl, shl, $($t)+););
+    (>>, $($t:tt)+) => ($crate::_impl_binary_op_internal!(Shr, shr, $($t)+););
 }
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _impl_binary_op_internal {
     ($ops_trait:ident, $ops_fn:ident, &$lhs:ty, &$rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => {
-        _impl_binary_op_borrowed_borrowed!(
+        $crate::_impl_binary_op_borrowed_borrowed!(
             $ops_trait, $ops_fn, $lhs, $rhs, $out, $lhs_i, $rhs_i, $body
         );
     };
     ($ops_trait:ident, $ops_fn:ident, &$lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => {
-        _impl_binary_op_borrowed_owned!(
+        $crate::_impl_binary_op_borrowed_owned!(
             $ops_trait, $ops_fn, $lhs, $rhs, $out, $lhs_i, $rhs_i, $body
         );
     };
     ($ops_trait:ident, $ops_fn:ident, $lhs:ty, &$rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => {
-        _impl_binary_op_owned_borrowed!(
+        $crate::_impl_binary_op_owned_borrowed!(
             $ops_trait, $ops_fn, $lhs, $rhs, $out, $lhs_i, $rhs_i, $body
         );
     };
     ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => {
-        _impl_binary_op_owned_owned!($ops_trait, $ops_fn, $lhs, $rhs, $out, $lhs_i, $rhs_i, $body);
+        $crate::_impl_binary_op_owned_owned!(
+            $ops_trait, $ops_fn, $lhs, $rhs, $out, $lhs_i, $rhs_i, $body
+        );
     };
 }
 

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -16,24 +16,30 @@ macro_rules! _parse_binary_op {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _impl_binary_op_internal {
-    ($ops_trait:ident, $ops_fn:ident, &$lhs:ty, &$rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => (
-        _impl_binary_op_borrowed_borrowed!($ops_trait, $ops_fn, $lhs, $rhs, $out, $lhs_i, $rhs_i, $body);
-    );
-    ($ops_trait:ident, $ops_fn:ident, &$lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => (
-        _impl_binary_op_borrowed_owned!($ops_trait, $ops_fn, $lhs, $rhs, $out, $lhs_i, $rhs_i, $body);
-    );
-    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, &$rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => (
-        _impl_binary_op_owned_borrowed!($ops_trait, $ops_fn, $lhs, $rhs, $out, $lhs_i, $rhs_i, $body);
-    );
-    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => (
+    ($ops_trait:ident, $ops_fn:ident, &$lhs:ty, &$rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => {
+        _impl_binary_op_borrowed_borrowed!(
+            $ops_trait, $ops_fn, $lhs, $rhs, $out, $lhs_i, $rhs_i, $body
+        );
+    };
+    ($ops_trait:ident, $ops_fn:ident, &$lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => {
+        _impl_binary_op_borrowed_owned!(
+            $ops_trait, $ops_fn, $lhs, $rhs, $out, $lhs_i, $rhs_i, $body
+        );
+    };
+    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, &$rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => {
+        _impl_binary_op_owned_borrowed!(
+            $ops_trait, $ops_fn, $lhs, $rhs, $out, $lhs_i, $rhs_i, $body
+        );
+    };
+    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => {
         _impl_binary_op_owned_owned!($ops_trait, $ops_fn, $lhs, $rhs, $out, $lhs_i, $rhs_i, $body);
-    );
+    };
 }
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _impl_binary_op_owned_owned {
-    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => (
+    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => {
         impl ops::$ops_trait<$rhs> for $lhs {
             type Output = $out;
 
@@ -41,15 +47,14 @@ macro_rules! _impl_binary_op_owned_owned {
                 let $lhs_i = self;
                 $body
             }
-                
         }
-    );
+    };
 }
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _impl_binary_op_owned_borrowed {
-    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => (
+    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => {
         impl<'a> ops::$ops_trait<&'a $rhs> for $lhs {
             type Output = $out;
 
@@ -57,15 +62,14 @@ macro_rules! _impl_binary_op_owned_borrowed {
                 let $lhs_i = self;
                 $body
             }
-                
         }
-    );
+    };
 }
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _impl_binary_op_borrowed_owned {
-    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => (
+    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => {
         impl<'a> ops::$ops_trait<$rhs> for &'a $lhs {
             type Output = $out;
 
@@ -73,15 +77,14 @@ macro_rules! _impl_binary_op_borrowed_owned {
                 let $lhs_i = self;
                 $body
             }
-                
         }
-    );
+    };
 }
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _impl_binary_op_borrowed_borrowed {
-    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => (
+    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $rhs:ty, $out:ty, $lhs_i:ident, $rhs_i:ident, $body:block) => {
         impl<'a, 'b> ops::$ops_trait<&'a $rhs> for &'b $lhs {
             type Output = $out;
 
@@ -89,7 +92,6 @@ macro_rules! _impl_binary_op_borrowed_borrowed {
                 let $lhs_i = self;
                 $body
             }
-                
         }
-    );
+    };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,42 +131,42 @@ mod unary;
 #[macro_export]
 macro_rules! impl_op {
     ($op:tt |$lhs_i:ident : &mut $lhs:path, $rhs_i:ident : &$rhs:path| $body:block) => {
-        _parse_assignment_op!($op, $lhs, &$rhs, lhs, rhs, {
+        $crate::_parse_assignment_op!($op, $lhs, &$rhs, lhs, rhs, {
             |$lhs_i: &mut $lhs, $rhs_i: &$rhs| -> () { $body }(lhs, rhs);
         });
     };
     ($op:tt |$lhs_i:ident : &mut $lhs:path, $rhs_i:ident : $rhs:path| $body:block) => {
-        _parse_assignment_op!($op, $lhs, $rhs, lhs, rhs, {
+        $crate::_parse_assignment_op!($op, $lhs, $rhs, lhs, rhs, {
             |$lhs_i: &mut $lhs, $rhs_i: $rhs| -> () { $body }(lhs, rhs);
         });
     };
     ($op:tt |$lhs_i:ident : &$lhs:path| -> $out:path $body:block) => {
-        _parse_unary_op!($op, &$lhs, $out, lhs, {
+        $crate::_parse_unary_op!($op, &$lhs, $out, lhs, {
             |$lhs_i: &$lhs| -> $out { $body }(lhs)
         });
     };
     ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => {
-        _parse_binary_op!($op, &$lhs, &$rhs, $out, lhs, rhs, {
+        $crate::_parse_binary_op!($op, &$lhs, &$rhs, $out, lhs, rhs, {
             |$lhs_i: &$lhs, $rhs_i: &$rhs| -> $out { $body }(lhs, rhs)
         });
     };
     ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => {
-        _parse_binary_op!($op, &$lhs, $rhs, $out, lhs, rhs, {
+        $crate::_parse_binary_op!($op, &$lhs, $rhs, $out, lhs, rhs, {
             |$lhs_i: &$lhs, $rhs_i: $rhs| -> $out { $body }(lhs, rhs)
         });
     };
     ($op:tt |$lhs_i:ident : $lhs:path| -> $out:path $body:block) => {
-        _parse_unary_op!($op, $lhs, $out, lhs, {
+        $crate::_parse_unary_op!($op, $lhs, $out, lhs, {
             |$lhs_i: $lhs| -> $out { $body }(lhs)
         });
     };
     ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => {
-        _parse_binary_op!($op, $lhs, &$rhs, $out, lhs, rhs, {
+        $crate::_parse_binary_op!($op, $lhs, &$rhs, $out, lhs, rhs, {
             |$lhs_i: $lhs, $rhs_i: &$rhs| -> $out { $body }(lhs, rhs)
         });
     };
     ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => {
-        _parse_binary_op!($op, $lhs, $rhs, $out, lhs, rhs, {
+        $crate::_parse_binary_op!($op, $lhs, $rhs, $out, lhs, rhs, {
             |$lhs_i: $lhs, $rhs_i: $rhs| -> $out { $body }(lhs, rhs)
         });
     };
@@ -224,35 +224,35 @@ macro_rules! impl_op {
 #[macro_export]
 macro_rules! impl_op_ex {
     ($op:tt |$lhs_i:ident : &mut $lhs:path, $rhs_i:ident : &$rhs:path| $body:block) => (
-        _parse_assignment_op!($op, $lhs, &$rhs, lhs, rhs, {|$lhs_i : &mut $lhs, $rhs_i : &$rhs| -> () {$body} (lhs, rhs);});
-        _parse_assignment_op!($op, $lhs, $rhs, lhs, rhs, {|$lhs_i : &mut $lhs, $rhs_i : &$rhs| -> () {$body} (lhs, &rhs);});
+        $crate::_parse_assignment_op!($op, $lhs, &$rhs, lhs, rhs, {|$lhs_i : &mut $lhs, $rhs_i : &$rhs| -> () {$body} (lhs, rhs);});
+        $crate::_parse_assignment_op!($op, $lhs, $rhs, lhs, rhs, {|$lhs_i : &mut $lhs, $rhs_i : &$rhs| -> () {$body} (lhs, &rhs);});
     );
     ($op:tt |$lhs_i:ident : &mut $lhs:path, $rhs_i:ident : $rhs:path| $body:block) => (
-        _parse_assignment_op!($op, $lhs, $rhs, lhs, rhs, {|$lhs_i : &mut $lhs, $rhs_i : $rhs| -> () {$body} (lhs, rhs);});
+        $crate::_parse_assignment_op!($op, $lhs, $rhs, lhs, rhs, {|$lhs_i : &mut $lhs, $rhs_i : $rhs| -> () {$body} (lhs, rhs);});
     );
     ($op:tt |$lhs_i:ident : &$lhs:path| -> $out:path $body:block) => (
-        _parse_unary_op!($op, &$lhs, $out, lhs, {|$lhs_i : &$lhs| -> $out {$body} (lhs)});
-        _parse_unary_op!($op, $lhs, $out, lhs, {|$lhs_i : &$lhs| -> $out {$body} (&lhs)});
+        $crate::_parse_unary_op!($op, &$lhs, $out, lhs, {|$lhs_i : &$lhs| -> $out {$body} (lhs)});
+        $crate::_parse_unary_op!($op, $lhs, $out, lhs, {|$lhs_i : &$lhs| -> $out {$body} (&lhs)});
     );
     ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => (
-        impl_op!($op |$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out $body);
-        _parse_binary_op!($op, &$lhs, $rhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (lhs, &rhs)});
-        _parse_binary_op!($op, $lhs, &$rhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (&lhs, rhs)});
-        _parse_binary_op!($op, $lhs, $rhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (&lhs, &rhs)});
+        $crate::impl_op!($op |$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out $body);
+        $crate::_parse_binary_op!($op, &$lhs, $rhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (lhs, &rhs)});
+        $crate::_parse_binary_op!($op, $lhs, &$rhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (&lhs, rhs)});
+        $crate::_parse_binary_op!($op, $lhs, $rhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (&lhs, &rhs)});
     );
     ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => (
-        impl_op!($op |$lhs_i : &$lhs, $rhs_i : $rhs| -> $out $body);
-        _parse_binary_op!($op, $lhs, $rhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : $rhs| -> $out {$body} (&lhs, rhs)});
+        $crate::impl_op!($op |$lhs_i : &$lhs, $rhs_i : $rhs| -> $out $body);
+        $crate::_parse_binary_op!($op, $lhs, $rhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : $rhs| -> $out {$body} (&lhs, rhs)});
     );
     ($op:tt |$lhs_i:ident : $lhs:path|  -> $out:path $body:block) => (
-        _parse_unary_op!($op, $lhs, $out, lhs, {|$lhs_i : $lhs| -> $out {$body} (lhs)});
+        $crate::_parse_unary_op!($op, $lhs, $out, lhs, {|$lhs_i : $lhs| -> $out {$body} (lhs)});
     );
     ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => (
-        impl_op!($op |$lhs_i : $lhs, $rhs_i : &$rhs| -> $out $body);
-        _parse_binary_op!($op, $lhs, $rhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : &$rhs| -> $out {$body} (lhs, &rhs)});
+        $crate::impl_op!($op |$lhs_i : $lhs, $rhs_i : &$rhs| -> $out $body);
+        $crate::_parse_binary_op!($op, $lhs, $rhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : &$rhs| -> $out {$body} (lhs, &rhs)});
     );
     ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => (
-        impl_op!($op |$lhs_i : $lhs, $rhs_i : $rhs| -> $out $body);
+        $crate::impl_op!($op |$lhs_i : $lhs, $rhs_i : $rhs| -> $out $body);
     );
 }
 
@@ -309,20 +309,20 @@ macro_rules! impl_op_ex {
 #[macro_export]
 macro_rules! impl_op_commutative {
     ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => (
-        impl_op!($op |$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out $body);
-        _parse_binary_op!($op, &$rhs, &$lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, lhs)});
+        $crate::impl_op!($op |$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out $body);
+        $crate::_parse_binary_op!($op, &$rhs, &$lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, lhs)});
     );
     ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => (
-        impl_op!($op |$lhs_i : &$lhs, $rhs_i : $rhs| -> $out $body);
-        _parse_binary_op!($op, $rhs, &$lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : $rhs| -> $out {$body} (rhs, lhs)});
+        $crate::impl_op!($op |$lhs_i : &$lhs, $rhs_i : $rhs| -> $out $body);
+        $crate::_parse_binary_op!($op, $rhs, &$lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : $rhs| -> $out {$body} (rhs, lhs)});
     );
     ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => (
-        impl_op!($op |$lhs_i : $lhs, $rhs_i : &$rhs| -> $out $body);
-        _parse_binary_op!($op, &$rhs, $lhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, lhs)});
+        $crate::impl_op!($op |$lhs_i : $lhs, $rhs_i : &$rhs| -> $out $body);
+        $crate::_parse_binary_op!($op, &$rhs, $lhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, lhs)});
     );
     ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => (
-        impl_op!($op |$lhs_i : $lhs, $rhs_i : $rhs| -> $out $body);
-        _parse_binary_op!($op, $rhs, $lhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : $rhs| -> $out {$body} (rhs, lhs)});
+        $crate::impl_op!($op |$lhs_i : $lhs, $rhs_i : $rhs| -> $out $body);
+        $crate::_parse_binary_op!($op, $rhs, $lhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : $rhs| -> $out {$body} (rhs, lhs)});
     );
 }
 
@@ -408,26 +408,26 @@ macro_rules! impl_op_commutative {
 #[macro_export]
 macro_rules! impl_op_ex_commutative {
     ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => (
-        impl_op_ex!($op |$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out $body);
+        $crate::impl_op_ex!($op |$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out $body);
 
-        _parse_binary_op!($op, &$rhs, &$lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, lhs)});
-        _parse_binary_op!($op, &$rhs, $lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (&rhs, lhs)});
-        _parse_binary_op!($op, $rhs, &$lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, &lhs)});
-        _parse_binary_op!($op, $rhs, $lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (&rhs, &lhs)});
+        $crate::_parse_binary_op!($op, &$rhs, &$lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, lhs)});
+        $crate::_parse_binary_op!($op, &$rhs, $lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (&rhs, lhs)});
+        $crate::_parse_binary_op!($op, $rhs, &$lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, &lhs)});
+        $crate::_parse_binary_op!($op, $rhs, $lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (&rhs, &lhs)});
     );
     ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => (
-        impl_op_ex!($op |$lhs_i : &$lhs, $rhs_i : $rhs| -> $out $body);
+        $crate::impl_op_ex!($op |$lhs_i : &$lhs, $rhs_i : $rhs| -> $out $body);
 
-        _parse_binary_op!($op, $rhs, &$lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : $rhs| -> $out {$body} (rhs, lhs)});
-        _parse_binary_op!($op, $rhs, $lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : $rhs| -> $out {$body} (&rhs, lhs)});
+        $crate::_parse_binary_op!($op, $rhs, &$lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : $rhs| -> $out {$body} (rhs, lhs)});
+        $crate::_parse_binary_op!($op, $rhs, $lhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : $rhs| -> $out {$body} (&rhs, lhs)});
     );
     ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => (
-        impl_op_ex!($op |$lhs_i : $lhs, $rhs_i : &$rhs| -> $out $body);
+        $crate::impl_op_ex!($op |$lhs_i : $lhs, $rhs_i : &$rhs| -> $out $body);
 
-        _parse_binary_op!($op, &$rhs, $lhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, lhs)});
-        _parse_binary_op!($op, $rhs, $lhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, &lhs)});
+        $crate::_parse_binary_op!($op, &$rhs, $lhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, lhs)});
+        $crate::_parse_binary_op!($op, $rhs, $lhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : &$rhs| -> $out {$body} (rhs, &lhs)});
     );
     ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => (
-        impl_op_commutative!($op |$lhs_i : $lhs, $rhs_i : $rhs| -> $out $body);
+        $crate::impl_op_commutative!($op |$lhs_i : $lhs, $rhs_i : $rhs| -> $out $body);
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! Macros for easy operator overloading.
-//! 
+//!
 //! The primary macro to learn is `impl_op!(<op> <closure>);`
 //! where `<op>` is an operator and `<closure>` is a closure with the same signature as the trait function associated with `<op>`.
 //! The macro you'll actually want to use most of the time, however, is [`impl_op_ex!`](macro.impl_op_ex.html). It works the same way as `impl_op!` but with some extra magic behind the scenes.
@@ -29,7 +29,7 @@
 //! // where
 //! // OP  : +, -, *, /, %, &, |, ^, <<, >>
 //! // a, b: variable names
-//! 
+//!
 //! #[macro_use] extern crate impl_ops;
 //! use std::ops;
 //! # #[derive(Clone, Debug, PartialEq)]
@@ -59,7 +59,7 @@
 //! // where
 //! // op  : +=, -=, *=, /=, %=, &=, |=, ^=, <<=, >>=
 //! // a, b: variable names
-//! 
+//!
 //! #[macro_use] extern crate impl_ops;
 //! use std::ops;
 //! # #[derive(Clone, Debug, PartialEq)]
@@ -115,7 +115,7 @@
 //! # Limitations
 //! * The output type of any operation must be an owned type (i.e. `impl_op!(+ |a: DonkeyKong b: i32| -> &DonkeyKong {...})` is invalid).
 //! * Types that have an unqualified lifetime or associated type are invalid
-//! 
+//!
 //! ```ignore
 //! // impl_op!(+ |a: SomeType<'a>, b: SomeType<'a>| -> SomeType<'a> {...}) // INVALID
 //! // impl_op!(+ |a: SomeType<T>, b: SomeType<T>| -> SomeType<T> {...})    // INVALID
@@ -130,34 +130,50 @@ mod unary;
 /// See the [module level documentation](index.html) for more information.
 #[macro_export]
 macro_rules! impl_op {
-    ($op:tt |$lhs_i:ident : &mut $lhs:path, $rhs_i:ident : &$rhs:path| $body:block) => (
-        _parse_assignment_op!($op, $lhs, &$rhs, lhs, rhs, {|$lhs_i : &mut $lhs, $rhs_i : &$rhs| -> () {$body} (lhs, rhs);});
-    );
-    ($op:tt |$lhs_i:ident : &mut $lhs:path, $rhs_i:ident : $rhs:path| $body:block) => (
-        _parse_assignment_op!($op, $lhs, $rhs, lhs, rhs, {|$lhs_i : &mut $lhs, $rhs_i : $rhs| -> () {$body} (lhs, rhs);});
-    );
-    ($op:tt |$lhs_i:ident : &$lhs:path| -> $out:path $body:block) => (
-        _parse_unary_op!($op, &$lhs, $out, lhs, {|$lhs_i : &$lhs| -> $out {$body} (lhs)});
-    );
-    ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => (
-        _parse_binary_op!($op, &$lhs, &$rhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : &$rhs| -> $out {$body} (lhs, rhs)});
-    );
-    ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => (
-        _parse_binary_op!($op, &$lhs, $rhs, $out, lhs, rhs, {|$lhs_i : &$lhs, $rhs_i : $rhs| -> $out {$body} (lhs, rhs)});
-    );
-    ($op:tt |$lhs_i:ident : $lhs:path| -> $out:path $body:block) => (
-        _parse_unary_op!($op, $lhs, $out, lhs, {|$lhs_i : $lhs| -> $out {$body} (lhs)});
-    );
-    ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => (
-        _parse_binary_op!($op, $lhs, &$rhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : &$rhs| -> $out {$body} (lhs, rhs)});
-    );
-    ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => (
-        _parse_binary_op!($op, $lhs, $rhs, $out, lhs, rhs, {|$lhs_i : $lhs, $rhs_i : $rhs| -> $out {$body} (lhs, rhs)});
-    );
+    ($op:tt |$lhs_i:ident : &mut $lhs:path, $rhs_i:ident : &$rhs:path| $body:block) => {
+        _parse_assignment_op!($op, $lhs, &$rhs, lhs, rhs, {
+            |$lhs_i: &mut $lhs, $rhs_i: &$rhs| -> () { $body }(lhs, rhs);
+        });
+    };
+    ($op:tt |$lhs_i:ident : &mut $lhs:path, $rhs_i:ident : $rhs:path| $body:block) => {
+        _parse_assignment_op!($op, $lhs, $rhs, lhs, rhs, {
+            |$lhs_i: &mut $lhs, $rhs_i: $rhs| -> () { $body }(lhs, rhs);
+        });
+    };
+    ($op:tt |$lhs_i:ident : &$lhs:path| -> $out:path $body:block) => {
+        _parse_unary_op!($op, &$lhs, $out, lhs, {
+            |$lhs_i: &$lhs| -> $out { $body }(lhs)
+        });
+    };
+    ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => {
+        _parse_binary_op!($op, &$lhs, &$rhs, $out, lhs, rhs, {
+            |$lhs_i: &$lhs, $rhs_i: &$rhs| -> $out { $body }(lhs, rhs)
+        });
+    };
+    ($op:tt |$lhs_i:ident : &$lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => {
+        _parse_binary_op!($op, &$lhs, $rhs, $out, lhs, rhs, {
+            |$lhs_i: &$lhs, $rhs_i: $rhs| -> $out { $body }(lhs, rhs)
+        });
+    };
+    ($op:tt |$lhs_i:ident : $lhs:path| -> $out:path $body:block) => {
+        _parse_unary_op!($op, $lhs, $out, lhs, {
+            |$lhs_i: $lhs| -> $out { $body }(lhs)
+        });
+    };
+    ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : &$rhs:path| -> $out:path $body:block) => {
+        _parse_binary_op!($op, $lhs, &$rhs, $out, lhs, rhs, {
+            |$lhs_i: $lhs, $rhs_i: &$rhs| -> $out { $body }(lhs, rhs)
+        });
+    };
+    ($op:tt |$lhs_i:ident : $lhs:path, $rhs_i:ident : $rhs:path| -> $out:path $body:block) => {
+        _parse_binary_op!($op, $lhs, $rhs, $out, lhs, rhs, {
+            |$lhs_i: $lhs, $rhs_i: $rhs| -> $out { $body }(lhs, rhs)
+        });
+    };
 }
 
 /// Overloads an operator using the given closure as its body. Generates overloads for both owned and borrowed variants where possible.
-/// 
+///
 /// Used with the same syntax as `impl_op!` (see the [module level documentation](index.html) for more information).
 ///
 /// Expands any borrowed inputs into both owned and borrowed variants.
@@ -171,7 +187,7 @@ macro_rules! impl_op {
 /// impl_op!(op |a: &LHS, b: RHS| -> OUT {...});
 /// impl_op!(op |a: &LHS, b: &RHS| -> OUT {...});
 /// ```
-/// 
+///
 /// and `impl_op_ex!(op |a: &LHS, b: RHS| -> OUT {...});`
 /// gets expanded to
 ///
@@ -241,7 +257,7 @@ macro_rules! impl_op_ex {
 }
 
 /// Overloads a binary operator commutatively using the given closure as its body.
-/// 
+///
 /// Used with the same syntax as `impl_op!` (see the [module level documentation](index.html) for more information).
 /// Can only be used with binary operators, and the operation must be between two different types.
 ///
@@ -287,7 +303,7 @@ macro_rules! impl_op_ex {
 ///     assert_eq!(4, total_bananas);
 ///     let total_bananas = 1 - DonkeyKong::new(5);
 ///     assert_eq!(4, total_bananas);
-///     // notice that in this case (5 - 1 == 4) and (1 - 5 == 1): that is the definition of a 
+///     // notice that in this case (5 - 1 == 4) and (1 - 5 == 1): that is the definition of a
 ///     // commutative operator, but probably not what you want for the '-' operator
 /// }
 #[macro_export]

--- a/src/unary.rs
+++ b/src/unary.rs
@@ -1,8 +1,8 @@
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _parse_unary_op {
-    (-, $($t:tt)+) => (_impl_unary_op_internal!(Neg, neg, $($t)+););
-    (!, $($t:tt)+) => (_impl_unary_op_internal!(Not, not, $($t)+););
+    (-, $($t:tt)+) => ($crate::_impl_unary_op_internal!(Neg, neg, $($t)+););
+    (!, $($t:tt)+) => ($crate::_impl_unary_op_internal!(Not, not, $($t)+););
 }
 
 #[doc(hidden)]

--- a/src/unary.rs
+++ b/src/unary.rs
@@ -8,7 +8,7 @@ macro_rules! _parse_unary_op {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _impl_unary_op_internal {
-    ($ops_trait:ident, $ops_fn:ident, &$lhs:ty, $out:ty, $lhs_i:ident, $body:block) => (        
+    ($ops_trait:ident, $ops_fn:ident, &$lhs:ty, $out:ty, $lhs_i:ident, $body:block) => {
         impl<'a> ops::$ops_trait for &'a $lhs {
             type Output = $out;
 
@@ -17,8 +17,8 @@ macro_rules! _impl_unary_op_internal {
                 $body
             }
         }
-    );
-    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $out:ty, $lhs_i:ident, $body:block) => (        
+    };
+    ($ops_trait:ident, $ops_fn:ident, $lhs:ty, $out:ty, $lhs_i:ident, $body:block) => {
         impl ops::$ops_trait for $lhs {
             type Output = $out;
 
@@ -27,5 +27,5 @@ macro_rules! _impl_unary_op_internal {
                 $body
             }
         }
-    );
+    };
 }

--- a/tests/assignment.rs
+++ b/tests/assignment.rs
@@ -204,7 +204,7 @@ mod multiline {
     use super::*;
 
     impl_op!(+= |a: &mut kong::Donkey, b: kong::Barrel<i32>| {
-        a.bananas += 0; 
+        a.bananas += 0;
         a.bananas += b.bananas;
     });
     #[test]
@@ -214,9 +214,9 @@ mod multiline {
         assert_eq!(kong::Donkey::new(3 + 2), dk);
     }
 
-    impl_op_ex!(-= |a: &mut kong::Donkey, b: &kong::Barrel<i32>| { 
+    impl_op_ex!(-= |a: &mut kong::Donkey, b: &kong::Barrel<i32>| {
         a.bananas += 0;
-        a.bananas -= b.bananas; 
+        a.bananas -= b.bananas;
     });
     #[test]
     fn impl_op_ex() {

--- a/tests/assignment.rs
+++ b/tests/assignment.rs
@@ -1,9 +1,7 @@
 //#![feature(trace_macros)]
 //trace_macros!(true);
 
-#[macro_use]
-extern crate impl_ops;
-
+use impl_ops::{impl_op, impl_op_ex};
 use std::ops;
 
 mod kong {

--- a/tests/binary.rs
+++ b/tests/binary.rs
@@ -58,85 +58,141 @@ mod impl_op_operators {
     impl_op!(+ |a: kong::Donkey, b: kong::Diddy| -> kong::Dixie { kong::Dixie::new(a.bananas + b.bananas) });
     #[test]
     fn add() {
-        assert_eq!(kong::Dixie::new(1 + 2), kong::Donkey::new(1) + kong::Diddy::new(2));
+        assert_eq!(
+            kong::Dixie::new(1 + 2),
+            kong::Donkey::new(1) + kong::Diddy::new(2)
+        );
     }
 
-    impl_op!(- |a: kong::Donkey, b: kong::Diddy| -> kong::Dixie { kong::Dixie::new(a.bananas - b.bananas) });
+    impl_op!(-|a: kong::Donkey, b: kong::Diddy| -> kong::Dixie {
+        kong::Dixie::new(a.bananas - b.bananas)
+    });
     #[test]
     fn sub() {
-        assert_eq!(kong::Dixie::new(1 - 2), kong::Donkey::new(1) - kong::Diddy::new(2));
+        assert_eq!(
+            kong::Dixie::new(1 - 2),
+            kong::Donkey::new(1) - kong::Diddy::new(2)
+        );
     }
 
-    impl_op!(* |a: kong::Donkey, b: kong::Diddy| -> kong::Dixie { kong::Dixie::new(a.bananas * b.bananas) });
+    impl_op!(*|a: kong::Donkey, b: kong::Diddy| -> kong::Dixie {
+        kong::Dixie::new(a.bananas * b.bananas)
+    });
     #[test]
     fn mul() {
-        assert_eq!(kong::Dixie::new(1 * 2), kong::Donkey::new(1) * kong::Diddy::new(2));
+        assert_eq!(
+            kong::Dixie::new(1 * 2),
+            kong::Donkey::new(1) * kong::Diddy::new(2)
+        );
     }
 
     impl_op!(/ |a: kong::Donkey, b: kong::Diddy| -> kong::Dixie { kong::Dixie::new(a.bananas / b.bananas) });
     #[test]
     fn div() {
-        assert_eq!(kong::Dixie::new(1 / 2), kong::Donkey::new(1) / kong::Diddy::new(2));
+        assert_eq!(
+            kong::Dixie::new(1 / 2),
+            kong::Donkey::new(1) / kong::Diddy::new(2)
+        );
     }
     impl_op!(% |a: kong::Donkey, b: kong::Diddy| -> kong::Dixie { kong::Dixie::new(a.bananas % b.bananas) });
     #[test]
     fn rem() {
-        assert_eq!(kong::Dixie::new(1 % 2), kong::Donkey::new(1) % kong::Diddy::new(2));
+        assert_eq!(
+            kong::Dixie::new(1 % 2),
+            kong::Donkey::new(1) % kong::Diddy::new(2)
+        );
     }
 
-    impl_op!(& |a: kong::Donkey, b: kong::Diddy| -> kong::Dixie { kong::Dixie::new(a.bananas & b.bananas) });
+    impl_op!(&|a: kong::Donkey, b: kong::Diddy| -> kong::Dixie {
+        kong::Dixie::new(a.bananas & b.bananas)
+    });
     #[test]
     fn bitand() {
-        assert_eq!(kong::Dixie::new(1 & 2), kong::Donkey::new(1) & kong::Diddy::new(2));
+        assert_eq!(
+            kong::Dixie::new(1 & 2),
+            kong::Donkey::new(1) & kong::Diddy::new(2)
+        );
     }
     impl_op!(| |a: kong::Donkey, b: kong::Diddy| -> kong::Dixie { kong::Dixie::new(a.bananas | b.bananas) });
     #[test]
     fn bitor() {
-        assert_eq!(kong::Dixie::new(1 | 2), kong::Donkey::new(1) | kong::Diddy::new(2));
+        assert_eq!(
+            kong::Dixie::new(1 | 2),
+            kong::Donkey::new(1) | kong::Diddy::new(2)
+        );
     }
     impl_op!(^ |a: kong::Donkey, b: kong::Diddy| -> kong::Dixie { kong::Dixie::new(a.bananas ^ b.bananas) });
     #[test]
     fn bitxor() {
-        assert_eq!(kong::Dixie::new(1 ^ 2), kong::Donkey::new(1) ^ kong::Diddy::new(2));
+        assert_eq!(
+            kong::Dixie::new(1 ^ 2),
+            kong::Donkey::new(1) ^ kong::Diddy::new(2)
+        );
     }
 
     impl_op!(<< |a: kong::Donkey, b: kong::Diddy| -> kong::Dixie { kong::Dixie::new(a.bananas << b.bananas) });
     #[test]
     fn shl() {
-        assert_eq!(kong::Dixie::new(1 << 2), kong::Donkey::new(1) << kong::Diddy::new(2));
+        assert_eq!(
+            kong::Dixie::new(1 << 2),
+            kong::Donkey::new(1) << kong::Diddy::new(2)
+        );
     }
     impl_op!(>> |a: kong::Donkey, b: kong::Diddy| -> kong::Dixie { kong::Dixie::new(a.bananas >> b.bananas) });
     #[test]
     fn shr() {
-        assert_eq!(kong::Dixie::new(1 >> 2), kong::Donkey::new(1) >> kong::Diddy::new(2));
+        assert_eq!(
+            kong::Dixie::new(1 >> 2),
+            kong::Donkey::new(1) >> kong::Diddy::new(2)
+        );
     }
 }
 
 mod impl_op_variants {
     use super::*;
 
-    impl_op!(- |a: kong::Diddy, b: kong::Dixie| -> kong::Donkey { kong::Donkey::new(a.bananas - b.bananas) });
+    impl_op!(-|a: kong::Diddy, b: kong::Dixie| -> kong::Donkey {
+        kong::Donkey::new(a.bananas - b.bananas)
+    });
     #[test]
     fn owned_owned() {
-        assert_eq!(kong::Donkey::new(1 - 2), kong::Diddy::new(1) - kong::Dixie::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 - 2),
+            kong::Diddy::new(1) - kong::Dixie::new(2)
+        );
     }
 
-    impl_op!(- |a: kong::Diddy, b: &kong::Dixie| -> kong::Donkey { kong::Donkey::new(a.bananas - b.bananas) });
+    impl_op!(-|a: kong::Diddy, b: &kong::Dixie| -> kong::Donkey {
+        kong::Donkey::new(a.bananas - b.bananas)
+    });
     #[test]
     fn owned_borrowed() {
-        assert_eq!(kong::Donkey::new(1 - 2), kong::Diddy::new(1) - &kong::Dixie::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 - 2),
+            kong::Diddy::new(1) - &kong::Dixie::new(2)
+        );
     }
 
-    impl_op!(- |a: &kong::Diddy, b: kong::Dixie| -> kong::Donkey { kong::Donkey::new(a.bananas - b.bananas) });
+    impl_op!(-|a: &kong::Diddy, b: kong::Dixie| -> kong::Donkey {
+        kong::Donkey::new(a.bananas - b.bananas)
+    });
     #[test]
     fn borrowed_owned() {
-        assert_eq!(kong::Donkey::new(1 - 2), &kong::Diddy::new(1) - kong::Dixie::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 - 2),
+            &kong::Diddy::new(1) - kong::Dixie::new(2)
+        );
     }
 
-    impl_op!(- |a: &kong::Diddy, b: &kong::Dixie| -> kong::Donkey { kong::Donkey::new(a.bananas - b.bananas) });
+    impl_op!(-|a: &kong::Diddy, b: &kong::Dixie| -> kong::Donkey {
+        kong::Donkey::new(a.bananas - b.bananas)
+    });
     #[test]
     fn borrowed_borrowed() {
-        assert_eq!(kong::Donkey::new(1 - 2), &kong::Diddy::new(1) - &kong::Dixie::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 - 2),
+            &kong::Diddy::new(1) - &kong::Dixie::new(2)
+        );
     }
 }
 
@@ -146,29 +202,57 @@ mod impl_op_commutative_variants {
     impl_op_commutative!(+ |a: kong::Diddy, b: kong::Dixie| -> kong::Donkey { kong::Donkey::new(a.bananas + b.bananas) });
     #[test]
     fn owned_owned() {
-        assert_eq!(kong::Donkey::new(1 + 2), kong::Diddy::new(1) + kong::Dixie::new(2));
-        assert_eq!(kong::Donkey::new(2 + 1), kong::Dixie::new(1) + kong::Diddy::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 + 2),
+            kong::Diddy::new(1) + kong::Dixie::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(2 + 1),
+            kong::Dixie::new(1) + kong::Diddy::new(2)
+        );
     }
 
     impl_op_commutative!(+ |a: kong::Diddy, b: &kong::Dixie| -> kong::Donkey { kong::Donkey::new(a.bananas + b.bananas) });
     #[test]
     fn owned_borrowed() {
-        assert_eq!(kong::Donkey::new(1 + 2), kong::Diddy::new(1) + &kong::Dixie::new(2));
-        assert_eq!(kong::Donkey::new(2 + 1), &kong::Dixie::new(1) + kong::Diddy::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 + 2),
+            kong::Diddy::new(1) + &kong::Dixie::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(2 + 1),
+            &kong::Dixie::new(1) + kong::Diddy::new(2)
+        );
     }
 
-    impl_op_commutative!(* |a: &kong::Diddy, b: kong::Dixie| -> kong::Donkey { kong::Donkey::new(a.bananas * b.bananas) });
+    impl_op_commutative!(*|a: &kong::Diddy, b: kong::Dixie| -> kong::Donkey {
+        kong::Donkey::new(a.bananas * b.bananas)
+    });
     #[test]
     fn borrowed_owned() {
-        assert_eq!(kong::Donkey::new(1 * 2), &kong::Diddy::new(1) * kong::Dixie::new(2));
-        assert_eq!(kong::Donkey::new(2 * 1), kong::Dixie::new(1) * &kong::Diddy::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 * 2),
+            &kong::Diddy::new(1) * kong::Dixie::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(2 * 1),
+            kong::Dixie::new(1) * &kong::Diddy::new(2)
+        );
     }
 
-    impl_op_commutative!(* |a: &kong::Diddy, b: &kong::Dixie| -> kong::Donkey { kong::Donkey::new(a.bananas * b.bananas) });
+    impl_op_commutative!(*|a: &kong::Diddy, b: &kong::Dixie| -> kong::Donkey {
+        kong::Donkey::new(a.bananas * b.bananas)
+    });
     #[test]
     fn borrowed_borrowed() {
-        assert_eq!(kong::Donkey::new(1 * 2), &kong::Diddy::new(1) * &kong::Dixie::new(2));
-        assert_eq!(kong::Donkey::new(2 * 1), &kong::Dixie::new(1) * &kong::Diddy::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 * 2),
+            &kong::Diddy::new(1) * &kong::Dixie::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(2 * 1),
+            &kong::Dixie::new(1) * &kong::Diddy::new(2)
+        );
     }
 }
 
@@ -178,30 +262,59 @@ mod impl_op_ex_variants {
     impl_op_ex!(/ |a: kong::Diddy, b: kong::Dixie| -> kong::Donkey { kong::Donkey::new(a.bananas / b.bananas) });
     #[test]
     fn owned_owned() {
-        assert_eq!(kong::Donkey::new(1 / 2), kong::Diddy::new(1) / kong::Dixie::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 / 2),
+            kong::Diddy::new(1) / kong::Dixie::new(2)
+        );
     }
 
     impl_op_ex!(% |a: kong::Diddy, b: &kong::Dixie| -> kong::Donkey { kong::Donkey::new(a.bananas % b.bananas) });
     #[test]
     fn owned_borrowed() {
-        assert_eq!(kong::Donkey::new(1 % 2), kong::Diddy::new(1) % &kong::Dixie::new(2));
-        assert_eq!(kong::Donkey::new(1 % 2), kong::Diddy::new(1) % kong::Dixie::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 % 2),
+            kong::Diddy::new(1) % &kong::Dixie::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(1 % 2),
+            kong::Diddy::new(1) % kong::Dixie::new(2)
+        );
     }
 
-    impl_op_ex!(& |a: &kong::Diddy, b: kong::Dixie| -> kong::Donkey { kong::Donkey::new(a.bananas & b.bananas) });
+    impl_op_ex!(&|a: &kong::Diddy, b: kong::Dixie| -> kong::Donkey {
+        kong::Donkey::new(a.bananas & b.bananas)
+    });
     #[test]
     fn borrowed_owned() {
-        assert_eq!(kong::Donkey::new(1 & 2), &kong::Diddy::new(1) & kong::Dixie::new(2));
-        assert_eq!(kong::Donkey::new(1 & 2), kong::Diddy::new(1) & kong::Dixie::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 & 2),
+            &kong::Diddy::new(1) & kong::Dixie::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(1 & 2),
+            kong::Diddy::new(1) & kong::Dixie::new(2)
+        );
     }
 
     impl_op_ex!(| |a: &kong::Diddy, b: &kong::Dixie| -> kong::Donkey { kong::Donkey::new(a.bananas | b.bananas) });
     #[test]
     fn borrowed_borrowed() {
-        assert_eq!(kong::Donkey::new(1 | 2), &kong::Diddy::new(1) | &kong::Dixie::new(2));
-        assert_eq!(kong::Donkey::new(1 | 2), &kong::Diddy::new(1) | kong::Dixie::new(2));
-        assert_eq!(kong::Donkey::new(1 | 2), kong::Diddy::new(1) | &kong::Dixie::new(2));
-        assert_eq!(kong::Donkey::new(1 | 2), kong::Diddy::new(1) | kong::Dixie::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 | 2),
+            &kong::Diddy::new(1) | &kong::Dixie::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(1 | 2),
+            &kong::Diddy::new(1) | kong::Dixie::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(1 | 2),
+            kong::Diddy::new(1) | &kong::Dixie::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(1 | 2),
+            kong::Diddy::new(1) | kong::Dixie::new(2)
+        );
     }
 }
 
@@ -211,42 +324,100 @@ mod impl_op_ex_commutative_variants {
     impl_op_ex_commutative!(+ |a: kong::Donkey, b: kong::Dixie| -> kong::Diddy { kong::Diddy::new(a.bananas + b.bananas) });
     #[test]
     fn owned_owned_ex_commutative() {
-        assert_eq!(kong::Diddy::new(1 + 2), kong::Donkey::new(1) + kong::Dixie::new(2));
-        assert_eq!(kong::Diddy::new(2 + 1), kong::Dixie::new(1) + kong::Donkey::new(2));
+        assert_eq!(
+            kong::Diddy::new(1 + 2),
+            kong::Donkey::new(1) + kong::Dixie::new(2)
+        );
+        assert_eq!(
+            kong::Diddy::new(2 + 1),
+            kong::Dixie::new(1) + kong::Donkey::new(2)
+        );
     }
 
-    impl_op_ex_commutative!(* |a: kong::Donkey, b: &kong::Dixie| -> kong::Diddy { kong::Diddy::new(a.bananas * b.bananas) });
+    impl_op_ex_commutative!(*|a: kong::Donkey, b: &kong::Dixie| -> kong::Diddy {
+        kong::Diddy::new(a.bananas * b.bananas)
+    });
     #[test]
     fn owned_borrowed() {
-        assert_eq!(kong::Diddy::new(1 * 2), kong::Donkey::new(1) * &kong::Dixie::new(2));
-        assert_eq!(kong::Diddy::new(1 * 2), kong::Donkey::new(1) * kong::Dixie::new(2));
+        assert_eq!(
+            kong::Diddy::new(1 * 2),
+            kong::Donkey::new(1) * &kong::Dixie::new(2)
+        );
+        assert_eq!(
+            kong::Diddy::new(1 * 2),
+            kong::Donkey::new(1) * kong::Dixie::new(2)
+        );
 
-        assert_eq!(kong::Diddy::new(2 * 1), &kong::Dixie::new(1) * kong::Donkey::new(2));
-        assert_eq!(kong::Diddy::new(2 * 1), kong::Dixie::new(1) * kong::Donkey::new(2));
+        assert_eq!(
+            kong::Diddy::new(2 * 1),
+            &kong::Dixie::new(1) * kong::Donkey::new(2)
+        );
+        assert_eq!(
+            kong::Diddy::new(2 * 1),
+            kong::Dixie::new(1) * kong::Donkey::new(2)
+        );
     }
 
-    impl_op_ex_commutative!(& |a: &kong::Donkey, b: kong::Dixie| -> kong::Diddy { kong::Diddy::new(a.bananas & b.bananas) });
+    impl_op_ex_commutative!(&|a: &kong::Donkey, b: kong::Dixie| -> kong::Diddy {
+        kong::Diddy::new(a.bananas & b.bananas)
+    });
     #[test]
     fn borrowed_owned() {
-        assert_eq!(kong::Diddy::new(1 & 2), &kong::Donkey::new(1) & kong::Dixie::new(2));
-        assert_eq!(kong::Diddy::new(1 & 2), kong::Donkey::new(1) & kong::Dixie::new(2));
+        assert_eq!(
+            kong::Diddy::new(1 & 2),
+            &kong::Donkey::new(1) & kong::Dixie::new(2)
+        );
+        assert_eq!(
+            kong::Diddy::new(1 & 2),
+            kong::Donkey::new(1) & kong::Dixie::new(2)
+        );
 
-        assert_eq!(kong::Diddy::new(2 & 1), kong::Dixie::new(1) & &kong::Donkey::new(2));
-        assert_eq!(kong::Diddy::new(2 & 1), kong::Dixie::new(1) & kong::Donkey::new(2));
+        assert_eq!(
+            kong::Diddy::new(2 & 1),
+            kong::Dixie::new(1) & &kong::Donkey::new(2)
+        );
+        assert_eq!(
+            kong::Diddy::new(2 & 1),
+            kong::Dixie::new(1) & kong::Donkey::new(2)
+        );
     }
 
     impl_op_ex_commutative!(| |a: &kong::Donkey, b: &kong::Dixie| -> kong::Diddy { kong::Diddy::new(a.bananas | b.bananas) });
     #[test]
     fn borrowed_borrowed() {
-        assert_eq!(kong::Diddy::new(1 | 2), &kong::Donkey::new(1) | &kong::Dixie::new(2));
-        assert_eq!(kong::Diddy::new(1 | 2), &kong::Donkey::new(1) | kong::Dixie::new(2));
-        assert_eq!(kong::Diddy::new(1 | 2), kong::Donkey::new(1) | &kong::Dixie::new(2));
-        assert_eq!(kong::Diddy::new(1 | 2), kong::Donkey::new(1) | kong::Dixie::new(2));
+        assert_eq!(
+            kong::Diddy::new(1 | 2),
+            &kong::Donkey::new(1) | &kong::Dixie::new(2)
+        );
+        assert_eq!(
+            kong::Diddy::new(1 | 2),
+            &kong::Donkey::new(1) | kong::Dixie::new(2)
+        );
+        assert_eq!(
+            kong::Diddy::new(1 | 2),
+            kong::Donkey::new(1) | &kong::Dixie::new(2)
+        );
+        assert_eq!(
+            kong::Diddy::new(1 | 2),
+            kong::Donkey::new(1) | kong::Dixie::new(2)
+        );
 
-        assert_eq!(kong::Diddy::new(2 | 1), &kong::Dixie::new(1) | &kong::Donkey::new(2));
-        assert_eq!(kong::Diddy::new(2 | 1), kong::Dixie::new(1) | &kong::Donkey::new(2));
-        assert_eq!(kong::Diddy::new(2 | 1), &kong::Dixie::new(1) | kong::Donkey::new(2));
-        assert_eq!(kong::Diddy::new(2 | 1), kong::Dixie::new(1) | kong::Donkey::new(2));
+        assert_eq!(
+            kong::Diddy::new(2 | 1),
+            &kong::Dixie::new(1) | &kong::Donkey::new(2)
+        );
+        assert_eq!(
+            kong::Diddy::new(2 | 1),
+            kong::Dixie::new(1) | &kong::Donkey::new(2)
+        );
+        assert_eq!(
+            kong::Diddy::new(2 | 1),
+            &kong::Dixie::new(1) | kong::Donkey::new(2)
+        );
+        assert_eq!(
+            kong::Diddy::new(2 | 1),
+            kong::Dixie::new(1) | kong::Donkey::new(2)
+        );
     }
 }
 
@@ -256,89 +427,191 @@ mod generics {
     impl_op!(+ |a: kong::Barrel<i32>, b: kong::Barrel<u32>| -> kong::Barrel<f32> { kong::Barrel::new((a.bananas + b.bananas as i32) as f32) });
     #[test]
     fn impl_op() {
-        assert_eq!(kong::Barrel::new((1 + 2) as f32), kong::Barrel::new(1) + kong::Barrel::new(2u32));
+        assert_eq!(
+            kong::Barrel::new((1 + 2) as f32),
+            kong::Barrel::new(1) + kong::Barrel::new(2u32)
+        );
     }
 
-    impl_op_commutative!(* |a: kong::Barrel<i32>, b: kong::Barrel<u32>| -> kong::Barrel<f32> { kong::Barrel::new((a.bananas * b.bananas as i32) as f32) });
+    impl_op_commutative!(
+        *|a: kong::Barrel<i32>, b: kong::Barrel<u32>| -> kong::Barrel<f32> {
+            kong::Barrel::new((a.bananas * b.bananas as i32) as f32)
+        }
+    );
     #[test]
     fn impl_op_commutative() {
-        assert_eq!(kong::Barrel::new((1 * 2) as f32), kong::Barrel::new(1) * kong::Barrel::new(2u32));
-        assert_eq!(kong::Barrel::new((2 * 1) as f32), kong::Barrel::new(1u32) * kong::Barrel::new(2));
+        assert_eq!(
+            kong::Barrel::new((1 * 2) as f32),
+            kong::Barrel::new(1) * kong::Barrel::new(2u32)
+        );
+        assert_eq!(
+            kong::Barrel::new((2 * 1) as f32),
+            kong::Barrel::new(1u32) * kong::Barrel::new(2)
+        );
     }
 
-    impl_op_ex!(- |a: &kong::Barrel<i32>, b: &kong::Barrel<u32>| -> kong::Barrel<f32> { kong::Barrel::new((a.bananas - b.bananas as i32) as f32) });
+    impl_op_ex!(
+        -|a: &kong::Barrel<i32>, b: &kong::Barrel<u32>| -> kong::Barrel<f32> {
+            kong::Barrel::new((a.bananas - b.bananas as i32) as f32)
+        }
+    );
     #[test]
     fn impl_op_ex() {
-        assert_eq!(kong::Barrel::new((1 - 2) as f32), kong::Barrel::new(1) - kong::Barrel::new(2u32));
-        assert_eq!(kong::Barrel::new((1 - 2) as f32), kong::Barrel::new(1) - &kong::Barrel::new(2u32));
-        assert_eq!(kong::Barrel::new((1 - 2) as f32), &kong::Barrel::new(1) - kong::Barrel::new(2u32));
-        assert_eq!(kong::Barrel::new((1 - 2) as f32), &kong::Barrel::new(1) - &kong::Barrel::new(2u32));
+        assert_eq!(
+            kong::Barrel::new((1 - 2) as f32),
+            kong::Barrel::new(1) - kong::Barrel::new(2u32)
+        );
+        assert_eq!(
+            kong::Barrel::new((1 - 2) as f32),
+            kong::Barrel::new(1) - &kong::Barrel::new(2u32)
+        );
+        assert_eq!(
+            kong::Barrel::new((1 - 2) as f32),
+            &kong::Barrel::new(1) - kong::Barrel::new(2u32)
+        );
+        assert_eq!(
+            kong::Barrel::new((1 - 2) as f32),
+            &kong::Barrel::new(1) - &kong::Barrel::new(2u32)
+        );
     }
 
-    impl_op_ex_commutative!(& |a: &kong::Barrel<i32>, b: &kong::Barrel<u32>| -> kong::Barrel<f32> { kong::Barrel::new((a.bananas & b.bananas as i32) as f32) });
+    impl_op_ex_commutative!(
+        &|a: &kong::Barrel<i32>, b: &kong::Barrel<u32>| -> kong::Barrel<f32> {
+            kong::Barrel::new((a.bananas & b.bananas as i32) as f32)
+        }
+    );
     #[test]
     fn impl_op_ex_commutative() {
-        assert_eq!(kong::Barrel::new((1 & 2) as f32), kong::Barrel::new(1) & kong::Barrel::new(2u32));
-        assert_eq!(kong::Barrel::new((1 & 2) as f32), kong::Barrel::new(1) & &kong::Barrel::new(2u32));
-        assert_eq!(kong::Barrel::new((1 & 2) as f32), &kong::Barrel::new(1) & kong::Barrel::new(2u32));
-        assert_eq!(kong::Barrel::new((1 & 2) as f32), &kong::Barrel::new(1) & &kong::Barrel::new(2u32));
+        assert_eq!(
+            kong::Barrel::new((1 & 2) as f32),
+            kong::Barrel::new(1) & kong::Barrel::new(2u32)
+        );
+        assert_eq!(
+            kong::Barrel::new((1 & 2) as f32),
+            kong::Barrel::new(1) & &kong::Barrel::new(2u32)
+        );
+        assert_eq!(
+            kong::Barrel::new((1 & 2) as f32),
+            &kong::Barrel::new(1) & kong::Barrel::new(2u32)
+        );
+        assert_eq!(
+            kong::Barrel::new((1 & 2) as f32),
+            &kong::Barrel::new(1) & &kong::Barrel::new(2u32)
+        );
 
-        assert_eq!(kong::Barrel::new((2 & 1) as f32), kong::Barrel::new(1u32) & kong::Barrel::new(2));
-        assert_eq!(kong::Barrel::new((2 & 1) as f32), kong::Barrel::new(1u32) & &kong::Barrel::new(2));
-        assert_eq!(kong::Barrel::new((2 & 1) as f32), &kong::Barrel::new(1u32) & kong::Barrel::new(2));
-        assert_eq!(kong::Barrel::new((2 & 1) as f32), &kong::Barrel::new(1u32) & &kong::Barrel::new(2));
+        assert_eq!(
+            kong::Barrel::new((2 & 1) as f32),
+            kong::Barrel::new(1u32) & kong::Barrel::new(2)
+        );
+        assert_eq!(
+            kong::Barrel::new((2 & 1) as f32),
+            kong::Barrel::new(1u32) & &kong::Barrel::new(2)
+        );
+        assert_eq!(
+            kong::Barrel::new((2 & 1) as f32),
+            &kong::Barrel::new(1u32) & kong::Barrel::new(2)
+        );
+        assert_eq!(
+            kong::Barrel::new((2 & 1) as f32),
+            &kong::Barrel::new(1u32) & &kong::Barrel::new(2)
+        );
     }
 }
 
 mod multiline {
     use super::*;
 
-    impl_op!(- |a: kong::Donkey, b: kong::Barrel<i32>| -> kong::Donkey { 
+    impl_op!(-|a: kong::Donkey, b: kong::Barrel<i32>| -> kong::Donkey {
         let ret = kong::Donkey::new(a.bananas - b.bananas);
-        ret 
+        ret
     });
     #[test]
     fn impl_op() {
-        assert_eq!(kong::Donkey::new(1 - 2), kong::Donkey::new(1) - kong::Barrel::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 - 2),
+            kong::Donkey::new(1) - kong::Barrel::new(2)
+        );
     }
 
-    impl_op_commutative!(+ |a: kong::Donkey, b: kong::Barrel<i32>| -> kong::Donkey { 
+    impl_op_commutative!(+ |a: kong::Donkey, b: kong::Barrel<i32>| -> kong::Donkey {
         let ret = kong::Donkey::new(a.bananas + b.bananas);
-        ret 
+        ret
     });
     #[test]
     fn impl_op_commutative() {
-        assert_eq!(kong::Donkey::new(1 + 2), kong::Donkey::new(1) + kong::Barrel::new(2));
-        assert_eq!(kong::Donkey::new(2 + 1), kong::Barrel::new(1) + kong::Donkey::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 + 2),
+            kong::Donkey::new(1) + kong::Barrel::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(2 + 1),
+            kong::Barrel::new(1) + kong::Donkey::new(2)
+        );
     }
 
-    impl_op_ex!(/ |a: &kong::Donkey, b: &kong::Barrel<i32>| -> kong::Donkey { 
+    impl_op_ex!(/ |a: &kong::Donkey, b: &kong::Barrel<i32>| -> kong::Donkey {
         let ret = kong::Donkey::new(a.bananas / b.bananas);
         ret
     });
     #[test]
     fn impl_op_ex() {
-        assert_eq!(kong::Donkey::new(1 / 2), kong::Donkey::new(1) / kong::Barrel::new(2));
-        assert_eq!(kong::Donkey::new(1 / 2), kong::Donkey::new(1) / &kong::Barrel::new(2));
-        assert_eq!(kong::Donkey::new(1 / 2), &kong::Donkey::new(1) / kong::Barrel::new(2));
-        assert_eq!(kong::Donkey::new(1 / 2), &kong::Donkey::new(1) / &kong::Barrel::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 / 2),
+            kong::Donkey::new(1) / kong::Barrel::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(1 / 2),
+            kong::Donkey::new(1) / &kong::Barrel::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(1 / 2),
+            &kong::Donkey::new(1) / kong::Barrel::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(1 / 2),
+            &kong::Donkey::new(1) / &kong::Barrel::new(2)
+        );
     }
 
-    impl_op_ex_commutative!(* |a: &kong::Donkey, b: &kong::Barrel<i32>| -> kong::Donkey { 
+    impl_op_ex_commutative!(*|a: &kong::Donkey, b: &kong::Barrel<i32>| -> kong::Donkey {
         let ret = kong::Donkey::new(a.bananas * b.bananas);
         ret
     });
     #[test]
     fn impl_op_ex_commutative() {
-        assert_eq!(kong::Donkey::new(1 * 2), kong::Donkey::new(1) * kong::Barrel::new(2));
-        assert_eq!(kong::Donkey::new(1 * 2), kong::Donkey::new(1) * &kong::Barrel::new(2));
-        assert_eq!(kong::Donkey::new(1 * 2), &kong::Donkey::new(1) * kong::Barrel::new(2));
-        assert_eq!(kong::Donkey::new(1 * 2), &kong::Donkey::new(1) * &kong::Barrel::new(2));
+        assert_eq!(
+            kong::Donkey::new(1 * 2),
+            kong::Donkey::new(1) * kong::Barrel::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(1 * 2),
+            kong::Donkey::new(1) * &kong::Barrel::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(1 * 2),
+            &kong::Donkey::new(1) * kong::Barrel::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(1 * 2),
+            &kong::Donkey::new(1) * &kong::Barrel::new(2)
+        );
 
-        assert_eq!(kong::Donkey::new(2 * 1), kong::Barrel::new(1) * kong::Donkey::new(2));
-        assert_eq!(kong::Donkey::new(2 * 1), kong::Barrel::new(1) * &kong::Donkey::new(2));
-        assert_eq!(kong::Donkey::new(2 * 1), &kong::Barrel::new(1) * kong::Donkey::new(2));
-        assert_eq!(kong::Donkey::new(2 * 1), &kong::Barrel::new(1) * &kong::Donkey::new(2));
+        assert_eq!(
+            kong::Donkey::new(2 * 1),
+            kong::Barrel::new(1) * kong::Donkey::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(2 * 1),
+            kong::Barrel::new(1) * &kong::Donkey::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(2 * 1),
+            &kong::Barrel::new(1) * kong::Donkey::new(2)
+        );
+        assert_eq!(
+            kong::Donkey::new(2 * 1),
+            &kong::Barrel::new(1) * &kong::Donkey::new(2)
+        );
     }
 }
 
@@ -352,6 +625,12 @@ fn do_bitor_2(a: &kong::Dixie, b: &kong::Donkey) -> kong::Diddy {
 
 #[test]
 fn infer_lifetimes() {
-    assert_eq!(kong::Diddy::new(1 | 2), do_bitor(&kong::Donkey::new(1), &kong::Dixie::new(2)));
-    assert_eq!(kong::Diddy::new(2 | 1), do_bitor_2(&kong::Dixie::new(1), &kong::Donkey::new(2)));
+    assert_eq!(
+        kong::Diddy::new(1 | 2),
+        do_bitor(&kong::Donkey::new(1), &kong::Dixie::new(2))
+    );
+    assert_eq!(
+        kong::Diddy::new(2 | 1),
+        do_bitor_2(&kong::Dixie::new(1), &kong::Donkey::new(2))
+    );
 }

--- a/tests/binary.rs
+++ b/tests/binary.rs
@@ -1,9 +1,7 @@
 //#![feature(trace_macros)]
 //trace_macros!(true);
 
-#[macro_use]
-extern crate impl_ops;
-
+use impl_ops::{impl_op, impl_op_commutative, impl_op_ex, impl_op_ex_commutative};
 use std::ops;
 
 mod kong {

--- a/tests/unary.rs
+++ b/tests/unary.rs
@@ -55,13 +55,13 @@ mod kong {
 mod impl_op_operators {
     use super::*;
 
-    impl_op!(! |a: kong::Donkey| -> kong::Diddy { kong::Diddy::new(a.bananas) });
+    impl_op!(!|a: kong::Donkey| -> kong::Diddy { kong::Diddy::new(a.bananas) });
     #[test]
     fn not() {
         assert_eq!(kong::Diddy::new(3), !kong::Donkey::new(3));
     }
 
-    impl_op!(- |a: kong::Donkey| -> kong::Diddy { kong::Diddy::new(-a.bananas) });
+    impl_op!(-|a: kong::Donkey| -> kong::Diddy { kong::Diddy::new(-a.bananas) });
     #[test]
     fn neg() {
         assert_eq!(kong::Diddy::new(-3), -kong::Donkey::new(3));
@@ -71,13 +71,13 @@ mod impl_op_operators {
 mod impl_op_variants {
     use super::*;
 
-    impl_op!(! |a: kong::Diddy| -> kong::Dixie { kong::Dixie::new(a.bananas) });
+    impl_op!(!|a: kong::Diddy| -> kong::Dixie { kong::Dixie::new(a.bananas) });
     #[test]
     fn owned() {
         assert_eq!(kong::Dixie::new(4), !kong::Diddy::new(4));
     }
 
-    impl_op!(! |a: &kong::Diddy| -> kong::Dixie { kong::Dixie::new(a.bananas) });
+    impl_op!(!|a: &kong::Diddy| -> kong::Dixie { kong::Dixie::new(a.bananas) });
     #[test]
     fn borrowed() {
         assert_eq!(kong::Dixie::new(4), !&kong::Diddy::new(4));
@@ -87,13 +87,13 @@ mod impl_op_variants {
 mod impl_op_ex_variants {
     use super::*;
 
-    impl_op_ex!(! |a: kong::Dixie| -> kong::Donkey { kong::Donkey::new(a.bananas) });
+    impl_op_ex!(!|a: kong::Dixie| -> kong::Donkey { kong::Donkey::new(a.bananas) });
     #[test]
     fn owned() {
         assert_eq!(kong::Donkey::new(4), !kong::Dixie::new(4));
     }
 
-    impl_op_ex!(- |a: &kong::Dixie| -> kong::Donkey { kong::Donkey::new(-a.bananas) });
+    impl_op_ex!(-|a: &kong::Dixie| -> kong::Donkey { kong::Donkey::new(-a.bananas) });
     #[test]
     fn borrowed() {
         assert_eq!(kong::Donkey::new(-4), -&kong::Dixie::new(4));
@@ -104,13 +104,15 @@ mod impl_op_ex_variants {
 mod generics {
     use super::*;
 
-    impl_op!(! |a: kong::Barrel<u32>| -> kong::Barrel<i32> { kong::Barrel::new(a.bananas as i32) });
+    impl_op!(!|a: kong::Barrel<u32>| -> kong::Barrel<i32> { kong::Barrel::new(a.bananas as i32) });
     #[test]
     fn impl_op() {
         assert_eq!(kong::Barrel::new(3), !kong::Barrel::new(3u32));
     }
 
-    impl_op_ex!(- |a: &kong::Barrel<u32>| -> kong::Barrel<i32> { kong::Barrel::new(-(a.bananas as i32)) });
+    impl_op_ex!(-|a: &kong::Barrel<u32>| -> kong::Barrel<i32> {
+        kong::Barrel::new(-(a.bananas as i32))
+    });
     #[test]
     fn impl_op_ex() {
         assert_eq!(kong::Barrel::new(-3), -&kong::Barrel::new(3u32));
@@ -121,18 +123,18 @@ mod generics {
 mod multiline {
     use super::*;
 
-    impl_op!(! |a: kong::Barrel<i32>| -> kong::Donkey {
-        let bananas = a.bananas; 
-        kong::Donkey::new(bananas) 
+    impl_op!(!|a: kong::Barrel<i32>| -> kong::Donkey {
+        let bananas = a.bananas;
+        kong::Donkey::new(bananas)
     });
     #[test]
     fn impl_op() {
         assert_eq!(kong::Donkey::new(3), !kong::Barrel::new(3));
     }
 
-    impl_op_ex!(- |a: &kong::Barrel<i32>| -> kong::Donkey { 
+    impl_op_ex!(-|a: &kong::Barrel<i32>| -> kong::Donkey {
         let bananas = a.bananas;
-        kong::Donkey::new(-bananas) 
+        kong::Donkey::new(-bananas)
     });
     #[test]
     fn impl_op_ex() {

--- a/tests/unary.rs
+++ b/tests/unary.rs
@@ -1,9 +1,7 @@
 //#![feature(trace_macros)]
 //trace_macros!(true);
 
-#[macro_use]
-extern crate impl_ops;
-
+use impl_ops::{impl_op, impl_op_ex};
 use std::ops;
 
 mod kong {


### PR DESCRIPTION
This PR makes 2018 edition macro imports work: 
```rust
use impl_ops::{impl_op, impl_op_ex};
```
Before it would complain that the internal implementation macros were not found, and the only way to make it work was to use `use impl_ops::*;` or go back to 
```rust
#[macro_use]
extern crate impl_ops;
```